### PR TITLE
Switch to header-based JWT auth

### DIFF
--- a/backend/controllers/auth.js
+++ b/backend/controllers/auth.js
@@ -83,18 +83,12 @@ exports.login = async (req, res) => {
       { expiresIn: '30d' }
     );
 
-    // HttpOnly 쿠키로 JWT 설정 (보안 강화)
-    res.cookie('token', token, {
-      httpOnly: true,
-      secure: process.env.NODE_ENV === 'production',
-      sameSite: 'none',
-      maxAge: 30 * 24 * 60 * 60 * 1000, // 30일
-    });
-
     logger.logAuth('login', studentId, true, { name, isAdmin: user.isAdmin });
 
+    // 토큰을 응답 본문으로 전달
     res.status(200).json({
       success: true,
+      token,
       user: {
         studentId: user.studentId,
         name: user.name,
@@ -149,16 +143,9 @@ exports.getMe = async (req, res) => {
 // @access  Private
 exports.logout = async (req, res) => {
   try {
-    // 쿠키 완전 삭제
-    res.cookie('token', 'none', {
-      expires: new Date(Date.now() + 10 * 1000), // 10초 후 만료
-      httpOnly: true,
-      secure: process.env.NODE_ENV === 'production',
-      sameSite: 'none',
-    });
-
     logger.logAuth('logout', req.user?.studentId || 'unknown', true);
 
+    // 쿠키 대신 클라이언트 저장소에서 토큰을 삭제하도록 안내
     res.status(200).json({
       success: true,
       message: 'User logged out successfully',

--- a/backend/middleware/auth.js
+++ b/backend/middleware/auth.js
@@ -13,10 +13,6 @@ exports.protect = async (req, res, next) => {
     // Set token from Bearer token in header
     token = req.headers.authorization.split(' ')[1];
   }
-  // Set token from cookie
-  else if (req.cookies.token) {
-    token = req.cookies.token;
-  }
 
   // Make sure token exists
   if (!token) {

--- a/backend/server.js
+++ b/backend/server.js
@@ -2,7 +2,6 @@ const express = require('express');
 const cors = require('cors');
 const mongoose = require('mongoose');
 const dotenv = require('dotenv');
-const cookieParser = require('cookie-parser');
 const logger = require('./utils/logger');
 
 // Load environment variables
@@ -52,7 +51,6 @@ app.options(
 
 // 기본 미들웨어 - 이 부분이 로깅 미들웨어보다 먼저 와야 함
 app.use(express.json());
-app.use(cookieParser());
 
 // HTTP 요청 로깅 미들웨어 (winston)
 app.use(logger.logRequest);
@@ -202,14 +200,7 @@ if (process.env.NODE_ENV === 'development') {
 
   // JWT 시크릿 변경 시 강제 로그아웃 API (임시)
   app.post('/api/debug/force-logout', (req, res) => {
-    logger.info('Force logout called - clearing all JWT cookies');
-
-    res.cookie('token', 'none', {
-      expires: new Date(Date.now() + 10 * 1000),
-      httpOnly: true,
-      secure: process.env.NODE_ENV === 'production',
-      sameSite: 'none',
-    });
+    logger.info('Force logout called');
 
     res.status(200).json({
       success: true,

--- a/frontend/pages/login.js
+++ b/frontend/pages/login.js
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react';
 import { useRouter } from 'next/router';
 import Layout from '../components/Layout';
 import { login, getAdminInfo } from '../utils/api';
-import { isAuthenticated } from '../utils/auth';
+import { isAuthenticated, setToken } from '../utils/auth';
 import { toast } from 'react-toastify';
 
 export default function Login() {
@@ -69,6 +69,9 @@ export default function Login() {
       );
       
       if (response.success) {
+        if (response.token) {
+          setToken(response.token);
+        }
         toast.success('로그인 성공!');
         
         // 관리자인 경우 관리자 대시보드로 리디렉션, 일반 사용자는 메인 페이지로 리디렉션

--- a/frontend/utils/api.js
+++ b/frontend/utils/api.js
@@ -17,12 +17,17 @@ const api = axios.create({
   headers: {
     'Content-Type': 'application/json',
   },
-  withCredentials: true, // 쿠키 자동 전송 설정
 });
 
-// Request interceptor - localStorage 제거, 쿠키는 자동으로 전송됨
+// Request interceptor - Authorization 헤더에 토큰 추가
 api.interceptors.request.use(
   (config) => {
+    if (typeof window !== 'undefined') {
+      const token = localStorage.getItem('token');
+      if (token) {
+        config.headers['Authorization'] = `Bearer ${token}`;
+      }
+    }
     return config;
   },
   (error) => {

--- a/frontend/utils/auth.js
+++ b/frontend/utils/auth.js
@@ -2,11 +2,32 @@ import { useRouter } from 'next/router';
 import { useEffect, useCallback, useState } from 'react';
 import { getMe, logout as apiLogout } from './api';
 
+// Token helpers
+export const setToken = (token) => {
+  if (typeof window !== 'undefined') {
+    localStorage.setItem('token', token);
+  }
+};
+
+export const getToken = () => {
+  if (typeof window === 'undefined') return null;
+  return localStorage.getItem('token');
+};
+
+export const removeToken = () => {
+  if (typeof window !== 'undefined') {
+    localStorage.removeItem('token');
+  }
+};
+
 // Check if user is authenticated by calling server
 export const isAuthenticated = async () => {
   if (typeof window === 'undefined') {
     return false;
   }
+
+  const token = getToken();
+  if (!token) return false;
 
   try {
     const response = await getMe();
@@ -23,6 +44,9 @@ export const getCurrentUser = async () => {
     return null;
   }
 
+  const token = getToken();
+  if (!token) return null;
+
   try {
     const response = await getMe();
     console.log(`Second block res: ${response}`);
@@ -37,12 +61,14 @@ export const logout = async (isAutoLogout = false) => {
   if (typeof window === 'undefined') return;
 
   try {
-    // 서버에서 쿠키 삭제
+    // 서버에 로그아웃 알림 (옵션)
     await apiLogout();
   } catch (error) {
     // 서버 호출 실패해도 클라이언트에서 로그아웃 진행
     console.error('Logout API call failed:', error);
   }
+
+  removeToken();
 
   // 자동 로그아웃 시 알림
   if (isAutoLogout) {


### PR DESCRIPTION
## Summary
- deliver JWT to clients via Authorization header, removing cookie usage
- strip cookie parsing from server
- adjust login UI to save the header token
- send Authorization token from axios requests
- store token in localStorage and adjust auth helpers
- document header-based approach

## Testing
- `npm test` (fails: Error: no test specified)
- `npm test` in frontend (fails: missing script)

------
https://chatgpt.com/codex/tasks/task_e_685f8017c240832f87d1603081eb8c25